### PR TITLE
Upgrade Farmer's Delight to 1.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,18 @@ group = mod_group_id
 repositories {
     //maven { url "https://maven.ryanliptak.com/" } // AppleSkin
     maven { url "https://www.cursemaven.com" }
+
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "Modrinth"
+                url = "https://api.modrinth.com/maven"
+            }
+        }
+        filter {
+            includeGroup "maven.modrinth"
+        }
+    }
 }
 
 base {
@@ -85,7 +97,7 @@ configurations {
 dependencies {
     implementation "net.neoforged:neoforge:${neo_version}"
 
-    implementation "curse.maven:farmers-delight-398521:${farmersdelight_version}"
+    implementation "maven.modrinth:farmers-delight:${farmersdelight_version}"
 
     // for testing
     //localRuntime "squeek.appleskin:appleskin-neoforge:mc1.21-3.0.5"

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,4 +30,4 @@ mod_credits=FoggyHillSide as original mod author
 update_json_url=https://raw.githubusercontent.com/Joshcraft2002/Dumplings-Delight-Rewrapped/main/update.json
 
 # Dependency Info
-farmersdelight_version=5962800
+farmersdelight_version=9gp7w8NC

--- a/src/main/java/cn/foggyhillside/dumplings_delight/block/EggplantBlock.java
+++ b/src/main/java/cn/foggyhillside/dumplings_delight/block/EggplantBlock.java
@@ -1,19 +1,20 @@
 package cn.foggyhillside.dumplings_delight.block;
 
+import cn.foggyhillside.dumplings_delight.registry.DumplingsDelightItems;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.*;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import cn.foggyhillside.dumplings_delight.registry.DumplingsDelightItems;
 import vectorwing.farmersdelight.common.registry.ModSounds;
 
 public class EggplantBlock extends CropBlock

--- a/src/main/java/cn/foggyhillside/dumplings_delight/block/EggplantBlock.java
+++ b/src/main/java/cn/foggyhillside/dumplings_delight/block/EggplantBlock.java
@@ -42,7 +42,7 @@ public class EggplantBlock extends CropBlock
             int quantity = 1 + level.random.nextInt(2);
             popResource(level, pos, new ItemStack(DumplingsDelightItems.EGGPLANT.get(), quantity));
 
-            level.playSound(null, pos, ModSounds.ITEM_TOMATO_PICK_FROM_BUSH.get(), SoundSource.BLOCKS, 1.0F, 0.8F + level.random.nextFloat() * 0.4F);
+            level.playSound(null, pos, ModSounds.BLOCK_TOMATOES_PICK_TOMATOES.get(), SoundSource.BLOCKS, 1.0F, 0.8F + level.random.nextFloat() * 0.4F);
             level.setBlock(pos, state.setValue(getAgeProperty(), 5), 2);
             return InteractionResult.SUCCESS;
         } else {

--- a/src/main/java/cn/foggyhillside/dumplings_delight/item/DumplingsDelightFoodValues.java
+++ b/src/main/java/cn/foggyhillside/dumplings_delight/item/DumplingsDelightFoodValues.java
@@ -6,13 +6,13 @@ import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.food.FoodProperties;
 
 import static vectorwing.farmersdelight.common.FoodValues.LONG_DURATION;
-import static vectorwing.farmersdelight.common.FoodValues.comfort;
+import static vectorwing.farmersdelight.common.FoodValues.nourishment;
 
 public class DumplingsDelightFoodValues {
     public static final FoodProperties PORK_CABBAGE_BOILED_DUMPLING = new FoodProperties.Builder().nutrition(8).saturationModifier(0.9F).build();
-    public static final FoodProperties PORK_CARROT_WONTON = new FoodProperties.Builder().nutrition(14).saturationModifier(0.5F).effect(() -> comfort(LONG_DURATION), 1.0F).build();
-    public static final FoodProperties PORK_MUSHROOM_WONTON = new FoodProperties.Builder().nutrition(12).saturationModifier(0.6F).effect(() -> comfort(LONG_DURATION), 1.0F).build();
-    public static final FoodProperties PORK_CABBAGE_WONTON = new FoodProperties.Builder().nutrition(11).saturationModifier(0.8F).effect(() -> comfort(LONG_DURATION), 1.0F).build();
+    public static final FoodProperties PORK_CARROT_WONTON = new FoodProperties.Builder().nutrition(14).saturationModifier(0.5F).effect(() -> nourishment(LONG_DURATION), 1.0F).build();
+    public static final FoodProperties PORK_MUSHROOM_WONTON = new FoodProperties.Builder().nutrition(12).saturationModifier(0.6F).effect(() -> nourishment(LONG_DURATION), 1.0F).build();
+    public static final FoodProperties PORK_CABBAGE_WONTON = new FoodProperties.Builder().nutrition(11).saturationModifier(0.8F).effect(() -> nourishment(LONG_DURATION), 1.0F).build();
     public static final FoodProperties FUNGUS_BOILED_DUMPLING = new FoodProperties.Builder().nutrition(6).saturationModifier(0.7F).build();
     public static final FoodProperties PORK_KELP_BOILED_DUMPLING = new FoodProperties.Builder().nutrition(7).saturationModifier(0.8F).build();
     public static final FoodProperties CALAMARI_BOILED_DUMPLING = new FoodProperties.Builder().nutrition(7).saturationModifier(0.8F).build();

--- a/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage0.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage0.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/chinese_cabbages_stage0"

--- a/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage1.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage1.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/chinese_cabbages_stage1"

--- a/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage2.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage2.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/chinese_cabbages_stage2"

--- a/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage3.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage3.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/chinese_cabbages_stage3"

--- a/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage4.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage4.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/chinese_cabbages_stage4"

--- a/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage5.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage5.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/chinese_cabbages_stage5"

--- a/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage6.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage6.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/chinese_cabbages_stage6"

--- a/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage7.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/chinese_cabbages_stage7.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/chinese_cabbages_stage7"

--- a/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage0.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage0.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/eggplant_stage0"

--- a/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage1.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage1.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/eggplant_stage1"

--- a/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage2.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage2.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/eggplant_stage2"

--- a/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage3.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage3.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/eggplant_stage3"

--- a/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage4.json
+++ b/src/main/resources/assets/dumplings_delight/models/block/eggplant_stage4.json
@@ -1,5 +1,5 @@
 {
-  "parent": "farmersdelight:block/crop_cross",
+  "parent": "farmersdelight:block/template_crop_cross",
   "render_type": "minecraft:cutout",
   "textures": {
     "cross": "dumplings_delight:block/eggplant_stage4"


### PR DESCRIPTION
**BREAKING CHANGE: Incompatible with Farmer's Delight 1.2.x**

Make mod compatible with latest Farmer's Delight (1.3.1)

Additionally, I have switched maven repository from curseforge to modrinth. since I am not familiar with curseforge's maven repo setup.

Tested on Minecraft 1.21.1-NeoForge_21.1.228
