### PR TITLE
Fix celery entry in Serene Seasons autumn block tag

### DIFF
--- a/src/main/resources/data/sereneseasons/tags/block/autumn_crops.json
+++ b/src/main/resources/data/sereneseasons/tags/block/autumn_crops.json
@@ -1,7 +1,7 @@
 {
   "replace": false,
   "values": [
-    "dumplings_delight:celery_seeds",
+    "dumplings_delight:celery",
     "dumplings_delight:chinese_cabbages",
     "dumplings_delight:fennel",
     "dumplings_delight:garlic",


### PR DESCRIPTION
The Serene Seasons autumn crop block tag currently references dumplings_delight:celery_seeds.

Because this file is under data/sereneseasons/tags/block, the entry needs to be a block id. celery_seeds is registered as an item, while the celery crop block is registered as dumplings_delight:celery.

This matches the existing spring crop block tag and avoids missing block tag reference errors during datapack reload.